### PR TITLE
fix: dark mode answer color

### DIFF
--- a/components/SearchDialog.tsx
+++ b/components/SearchDialog.tsx
@@ -236,7 +236,7 @@ export function SearchDialog() {
               )}
 
               {answer && !hasError ? (
-                <div className="flex items-center gap-4">
+                <div className="flex items-center gap-4 dark:text-white">
                   <span className="bg-green-500 p-2 w-8 h-8 rounded-full text-center flex items-center justify-center">
                     <Wand width={18} className="text-white" />
                   </span>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixed the answer text being hardly visible in dark mode due to default text color.

## What is the current behavior?

![image](https://user-images.githubusercontent.com/9266227/230556900-47e129dd-0208-4c4f-a62b-186a06b6be73.png)

## What is the new behavior?

![image](https://user-images.githubusercontent.com/9266227/230556955-7d239eaa-d2b6-4c5c-8379-3448a70eeff5.png)
