### PR TITLE
chore: remove local env vars to avoid confusion.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
-# Local supabase keys prefilled `supabase start`.
+# For local development, run `supabase status` to get credentials.
 # For hosted instance keys head to https://app.supabase.com/project/_/settings/api
 NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
-NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
-SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
 
 # Get your key at https://platform.openai.com/account/api-keys
 OPENAI_KEY=


### PR DESCRIPTION
I initially thought that prefilling the `.env.example` file with the local development keys would be convenient, but I think it can lead to confusion and leaked keys instead. 