### PR TITLE
Fix to prevent dialogue overflowing from large reply

### DIFF
--- a/components/SearchDialog.tsx
+++ b/components/SearchDialog.tsx
@@ -75,7 +75,7 @@ export function SearchDialog() {
         </kbd>{' '}
       </button>
       <Dialog open={open}>
-        <DialogContent className="sm:max-w-[850px] text-black">
+        <DialogContent className="sm:max-w-[850px] max-h-[80vh] overflow-y-auto text-black">
           <DialogHeader>
             <DialogTitle>OpenAI powered doc search</DialogTitle>
             <DialogDescription>


### PR DESCRIPTION
## What kind of change does this PR introduce?
Max dialogue height and overflow-auto scroll bar on Y axis

Bug fix, feature, docs update, ...
Dialogue overflow on large output

## What is the current behavior?
Dialogue overflow on large output

Please link any relevant issues here.
[Issue Long replies breaks...](https://github.com/supabase-community/nextjs-openai-doc-search/issues/40)

## What is the new behavior?
DIalogue has max height and overflow scrollbar

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
