### PR TITLE
chore: add minimum release age protection

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 4320


### PR DESCRIPTION
## What

Adds a minimum-release-age guard for npm/pnpm so this repo will not install
packages newer than 4320 minutes (72h / 3 days) old at install time.

- Package manager detected: `pnpm`
- File updated: `pnpm-workspace.yaml`
- Value: `4320` minutes (72 hours / 3 days)

## Why

Recent npm supply-chain attacks (malicious versions of `chalk`, `debug`,
`color-name`, the `Shai-Hulud` self-propagating worm, etc.) were typically
caught and yanked within hours of publish. Holding new versions for 72 hours
(3 days) before installing them dramatically reduces exposure to 0-day
malicious publishes without meaningfully slowing day-to-day development.

References:
- pnpm: https://pnpm.io/settings#minimumreleaseage
- npm:  https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age

## Risk / rollout

- No functional change to application code.
- Only affects fresh installs of versions less than 72h old.
- Reversible by removing the setting.

_Generated by min-release-age-migration.sh._
